### PR TITLE
[FIX] partner_invoicing_mode_cash_on_delivery - do not invoice SO when pick is done

### DIFF
--- a/partner_invoicing_mode_cash_on_delivery/models/stock_picking.py
+++ b/partner_invoicing_mode_cash_on_delivery/models/stock_picking.py
@@ -28,7 +28,10 @@ class StockPicking(models.Model):
         """
         self.ensure_one()
         res = super()._invoice_at_shipping()
-        res = res or self.sale_id.payment_mode_id.cash_on_delivery
+        res = res or (
+            self.picking_type_code == "outgoing"
+            and self.sale_id.payment_mode_id.cash_on_delivery
+        )
         return res
 
     def _invoicing_at_shipping_validation(self, invoices):


### PR DESCRIPTION
Do not trigger invoicing on internal operations